### PR TITLE
Expand omnimatch class

### DIFF
--- a/app/src/main/java/com/dimagi/biometric/ParamConstants.java
+++ b/app/src/main/java/com/dimagi/biometric/ParamConstants.java
@@ -31,5 +31,5 @@ public class ParamConstants {
     public static final String TEMPLATE_PROP_NAME = "template_prop_name";
     public static final String TEMPLATE_PROP_NAME_DEFAULT = "bio_template";
     public static final String ACCEPTANCE_THRESHOLD_NAME = "acceptance_threshold";
-    public static final float ACCEPTANCE_THRESHOLD_DEFAULT = 10.0f;
+    public static final float ACCEPTANCE_THRESHOLD_DEFAULT = 4.0f;
 }

--- a/app/src/main/java/com/dimagi/biometric/ParamManager.java
+++ b/app/src/main/java/com/dimagi/biometric/ParamManager.java
@@ -1,0 +1,154 @@
+package com.dimagi.biometric;
+
+import ai.tech5.finger.utils.SegmentationMode;
+
+/**
+ * Data class used for getting and setting various input parameters. Validation is done on setter
+ * methods to ensure that the values stays within constraints.
+ */
+public class ParamManager {
+
+    private int pitch = ParamConstants.PITCH_DEFAULT;
+    private int yaw = ParamConstants.YAW_DEFAULT;
+    private int roll = ParamConstants.ROLL_DEFAULT;
+    private float mask = ParamConstants.MASK_DEFAULT;
+    private float sunglasses = ParamConstants.SUNGLASSES_DEFAULT;
+    private float eyesClosed = ParamConstants.EYES_CLOSED_DEFAULT;
+    private int brisque = ParamConstants.BRISQUE_DEFAULT;
+    private float imageCenterTolerance = ParamConstants.IMAGE_CENTER_TOLERANCE_DEFAULT;
+    private boolean autoCaptureEnabled = ParamConstants.AUTO_CAPTURE_ENABLED_DEFAULT;
+    private float detectorThreshold = ParamConstants.DETECTOR_THRESHOLD_DEFAULT;
+    private int timeoutSecs = ParamConstants.TIMEOUT_SECS_DEFAULT;
+    private SegmentationMode segmentationMode = ParamConstants.SEGMENTATION_MODE_DEFAULT;
+
+    private int clampValue(int val, int min, int max) {
+        return Math.max(min, Math.min(max, val));
+    }
+
+    private float clampValue(float val, float min, float max) {
+        return Math.max(min, Math.min(max, val));
+    }
+
+    public ParamManager() {}
+
+    public void setPitch(int pitch) {
+        this.pitch = clampValue(pitch, -90, 90);
+    }
+
+    public int getPitch() {
+        return pitch;
+    }
+
+    public void setYaw(int yaw) {
+        this.yaw = clampValue(yaw, -90, 90);
+    }
+
+    public int getYaw() {
+        return yaw;
+    }
+
+    public void setRoll(int roll) {
+        this.roll = clampValue(roll, -90, 90);
+    }
+
+    public int getRoll() {
+        return roll;
+    }
+
+    public void setMask(float mask) {
+        this.mask = clampValue(mask, 0, 1);
+    }
+
+    public float getMask() {
+        return mask;
+    }
+
+    public void setSunglasses(float sunglasses) {
+        this.sunglasses = clampValue(sunglasses, 0, 1);
+    }
+
+    public float getSunglasses() {
+        return sunglasses;
+    }
+
+    public void setEyesClosed(float eyesClosed) {
+        this.eyesClosed = clampValue(eyesClosed, 0, 1);
+    }
+
+    public float getEyesClosed() {
+        return eyesClosed;
+    }
+
+    public void setBrisque(int brisque) {
+        this.brisque = clampValue(brisque, 0, 100);
+    }
+
+    public int getBrisque() {
+        return brisque;
+    }
+
+    public void setImageCenterTolerance(float imageCenterTolerance) {
+        this.imageCenterTolerance = clampValue(imageCenterTolerance, 2, 50);
+    }
+
+    public float getImageCenterTolerance() {
+        return imageCenterTolerance;
+    }
+
+    public void setAutoCaptureEnabled(boolean autoCaptureEnabled) {
+        this.autoCaptureEnabled = autoCaptureEnabled;
+    }
+
+    public boolean getAutoCaptureEnabled() {
+        return autoCaptureEnabled;
+    }
+
+    public void setDetectorThreshold(float detectorThreshold) {
+        this.detectorThreshold = clampValue(detectorThreshold,0, 1);
+    }
+
+    public float getDetectorThreshold() {
+        return detectorThreshold;
+    }
+
+    public void setTimeoutSecs(int timeoutSecs) {
+        this.timeoutSecs = clampValue(timeoutSecs, 1, 60);
+    }
+
+    public int getTimeoutSecs() {
+        return timeoutSecs;
+    }
+
+    public void setSegmentationMode(String mode) {
+        if (mode == null) {
+            return;
+        }
+        switch (mode) {
+            case "left_thumb":
+                segmentationMode = SegmentationMode.SEGMENTATION_MODE_LEFT_THUMB;
+                break;
+            case "right_thumb":
+                segmentationMode = SegmentationMode.SEGMENTATION_MODE_RIGHT_THUMB;
+                break;
+            case "left_index":
+                segmentationMode = SegmentationMode.SEGMENTATION_MODE_LEFT_INDEX;
+                break;
+            case "right_index":
+                segmentationMode = SegmentationMode.SEGMENTATION_MODE_RIGHT_INDEX;
+                break;
+            case "right_hand":
+                segmentationMode = SegmentationMode.SEGMENTATION_MODE_RIGHT_SLAP;
+                break;
+            case "left_hand":
+                segmentationMode = SegmentationMode.SEGMENTATION_MODE_LEFT_SLAP;
+                break;
+            case "both_thumbs":
+            default:
+                segmentationMode = SegmentationMode.SEGMENTATION_MODE_LEFT_AND_RIGHT_THUMBS;
+        }
+    }
+
+    public SegmentationMode getSegmentationMode() {
+        return segmentationMode;
+    }
+}

--- a/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
@@ -1,6 +1,5 @@
 package com.dimagi.biometric.activities;
 
-
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
@@ -46,6 +45,7 @@ public abstract class BaseActivity extends AppCompatActivity {
 
     protected abstract void onCaptureSuccess(MatcherCommon.Record activeRecord);
     protected abstract void onCaptureCancelled();
+    protected abstract ArrayList<String> validateRequiredParams();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -71,6 +71,13 @@ public abstract class BaseActivity extends AppCompatActivity {
     }
 
     protected void loadFragment(Fragment fragment) {
+        ArrayList<String> errors = validateRequiredParams();
+        if (errors.size() > 0) {
+            Bundle args = new Bundle();
+            String errorStr = createErrorStr(errors);
+            args.putString("errors", errorStr);
+            fragment.setArguments(args);
+        }
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         ft.add(R.id.mainContainer, fragment, MATCH_FRAGMENT_TAG);
         ft.commit();
@@ -132,8 +139,7 @@ public abstract class BaseActivity extends AppCompatActivity {
                     matchFragment = new FingerMatchFragment();
                 }
                 loadFragment(matchFragment);
-            }
-            else if (status == LicenseViewModel.initStatus.FAIL || status == LicenseViewModel.initStatus.NO_NETWORK) {
+            } else {
                 toggleRetryButton(true);
             }
         });
@@ -196,6 +202,14 @@ public abstract class BaseActivity extends AppCompatActivity {
         caseId = savedInstanceState.getString(CASE_ID_PARAM);
         biometricType = (BioCommon.BioType)savedInstanceState.getSerializable(BIOMETRIC_TYPE_PARAM);
         initTemplateViewModel();
+    }
+
+    private String createErrorStr(ArrayList<String> errors) {
+        StringBuilder errorStr = new StringBuilder();
+        for (String error : errors) {
+            errorStr.append(error).append("\n");
+        }
+        return errorStr.toString();
     }
 }
 

--- a/app/src/main/java/com/dimagi/biometric/activities/EnrollActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/EnrollActivity.java
@@ -30,4 +30,9 @@ public class EnrollActivity extends BaseActivity {
         // TODO: Return to CC with cancelled output. This is pending required changes to the CC Support Library
         // IdentityResponseBuilder.registrationResponse(caseId).finalizeResponse(this);
     }
+
+    @Override
+    protected ArrayList<String> validateRequiredParams() {
+        return new ArrayList<>();
+    }
 }

--- a/app/src/main/java/com/dimagi/biometric/activities/SearchActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/SearchActivity.java
@@ -66,4 +66,13 @@ public class SearchActivity extends BaseActivity {
         }
         return identifications;
     }
+
+    @Override
+    protected ArrayList<String> validateRequiredParams() {
+        ArrayList<String> errors = new ArrayList<>();
+        if (caseId == null) {
+            errors.add(getText(R.string.missing_case_id).toString());
+        }
+        return errors;
+    }
 }

--- a/app/src/main/java/com/dimagi/biometric/activities/VerifyActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/VerifyActivity.java
@@ -33,4 +33,16 @@ public class VerifyActivity extends BaseActivity {
                 caseId, new MatchResult(0, MatchStrength.ONE_STAR)
         ).finalizeResponse(this);
     }
+
+    @Override
+    protected ArrayList<String> validateRequiredParams() {
+        ArrayList<String> errors = new ArrayList<>();
+        if (caseId == null) {
+            errors.add(getText(R.string.missing_case_id).toString());
+        }
+        if (templateStr == null) {
+            errors.add(getText(R.string.missing_template_str).toString());
+        }
+        return errors;
+    }
 }

--- a/app/src/main/java/com/dimagi/biometric/fragments/BaseMatchFragment.java
+++ b/app/src/main/java/com/dimagi/biometric/fragments/BaseMatchFragment.java
@@ -24,6 +24,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
+import com.dimagi.biometric.ParamManager;
 import com.dimagi.biometric.R;
 
 import java.util.ArrayList;
@@ -54,6 +55,7 @@ public abstract class BaseMatchFragment extends Fragment {
 
     protected abstract void handleStartCapture();
     protected abstract void handleCancelCapture();
+    protected abstract ParamManager getParams();
 
     public BaseMatchFragment() {
         // Required empty public constructor

--- a/app/src/main/java/com/dimagi/biometric/fragments/BaseMatchFragment.java
+++ b/app/src/main/java/com/dimagi/biometric/fragments/BaseMatchFragment.java
@@ -11,6 +11,7 @@ import android.Manifest;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
@@ -61,14 +62,29 @@ public abstract class BaseMatchFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_main_menu, container, false);
-        Button startButton = view.findViewById(R.id.start_capture_button);
-        startButton.setOnClickListener(v -> handleStartClick());
         Button cancelButton = view.findViewById(R.id.cancel_capture_button);
         cancelButton.setOnClickListener(v -> handleCancelCapture());
         if (savedInstanceState != null) {
             restoreDialog(savedInstanceState);
         }
         return view;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        Bundle args = getArguments();
+        String errors = null;
+        if (args != null) {
+            errors = args.getString("errors");
+        }
+        Button startButton = view.findViewById(R.id.start_capture_button);
+        if (errors == null) {
+            startButton.setOnClickListener(v -> handleStartClick());
+        } else {
+            startButton.setEnabled(false);
+            handleErrorMessage(errors);
+        }
     }
 
     private final ActivityResultLauncher<String[]> requestPermissionLauncher =
@@ -122,8 +138,8 @@ public abstract class BaseMatchFragment extends Fragment {
         try {
             TextView errorText = requireView().findViewById(R.id.error_text);
             errorText.setText(error);
-        } catch (NullPointerException ex) {
-            Log.e(TAG, "Null pointer on trying to set error message");
+        } catch (NullPointerException | IllegalStateException e) {
+            Log.e(TAG, "Exception trying to create main menu error message: " + e);
         }
     }
 

--- a/app/src/main/java/com/dimagi/biometric/fragments/FaceMatchFragment.java
+++ b/app/src/main/java/com/dimagi/biometric/fragments/FaceMatchFragment.java
@@ -1,5 +1,6 @@
 package com.dimagi.biometric.fragments;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -7,6 +8,8 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.dimagi.biometric.ParamManager;
+import com.dimagi.biometric.ParamConstants;
 import com.dimagi.biometric.viewmodels.FaceMatchViewModel;
 import com.phoenixcapture.camerakit.FaceBox;
 
@@ -16,6 +19,7 @@ import java.util.List;
 import Tech5.OmniMatch.BioCommon;
 import Tech5.OmniMatch.Common;
 import Tech5.OmniMatch.MatcherCommon;
+import ai.tech5.pheonix.capture.controller.AirsnapFaceThresholds;
 import ai.tech5.pheonix.capture.controller.FaceCaptureController;
 import ai.tech5.pheonix.capture.controller.FaceCaptureListener;
 
@@ -30,15 +34,30 @@ public class FaceMatchFragment extends BaseMatchFragment implements FaceCaptureL
 
     @Override
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
         faceMatchViewModel = new ViewModelProvider(requireActivity()).get(FaceMatchViewModel.class);
     }
 
     @Override
     protected void handleStartCapture() {
+        ParamManager params = getParams();
+
         FaceCaptureController controller = FaceCaptureController.getInstance();
         controller.setUseBackCamera(false);
-        controller.setAutoCapture(true);
+        controller.setAutoCapture(params.getAutoCaptureEnabled());
+        controller.setCaptureTimeoutInSecs(params.getTimeoutSecs());
 
+        AirsnapFaceThresholds thresholds = new AirsnapFaceThresholds();
+        thresholds.setPITCH_THRESHOLD(params.getPitch());
+        thresholds.setYAW_THRESHOLD(params.getYaw());
+        thresholds.setRollThreshold(params.getRoll());
+        thresholds.setMASK_THRESHOLD(params.getMask());
+        thresholds.setSUNGLASS_THRESHOLD(params.getSunglasses());
+        thresholds.setEYE_CLOSE_THRESHOLD(params.getEyesClosed());
+        thresholds.setBRISQUE_THRESHOLD(params.getBrisque());
+        thresholds.setFaceCentreToImageCentreTolerance(params.getImageCenterTolerance());
+
+        controller.setAirsnapFaceThresholds(thresholds);
         controller.startFaceCapture("", requireContext(), this);
     }
 
@@ -75,5 +94,22 @@ public class FaceMatchFragment extends BaseMatchFragment implements FaceCaptureL
     @Override
     public void onTimedout(byte[] faceImage) {
         handleErrorMessage("Failed to capture face image: Timed out");
+    }
+
+    @Override
+    protected ParamManager getParams() {
+        Intent intent = requireActivity().getIntent();
+        ParamManager params = new ParamManager();
+        params.setPitch(intent.getIntExtra(ParamConstants.PITCH_NAME, ParamConstants.PITCH_DEFAULT));
+        params.setYaw(intent.getIntExtra(ParamConstants.YAW_NAME, ParamConstants.YAW_DEFAULT));
+        params.setRoll(intent.getIntExtra(ParamConstants.ROLL_NAME, ParamConstants.ROLL_DEFAULT));
+        params.setMask(intent.getFloatExtra(ParamConstants.MASK_NAME, ParamConstants.MASK_DEFAULT));
+        params.setSunglasses(intent.getFloatExtra(ParamConstants.SUNGLASSES_NAME, ParamConstants.SUNGLASSES_DEFAULT));
+        params.setEyesClosed(intent.getFloatExtra(ParamConstants.EYES_CLOSED_NAME, ParamConstants.EYES_CLOSED_DEFAULT));
+        params.setBrisque(intent.getIntExtra(ParamConstants.BRISQUE_NAME, ParamConstants.BRISQUE_DEFAULT));
+        params.setImageCenterTolerance(intent.getFloatExtra(ParamConstants.IMAGE_CENTER_TOLERANCE_NAME, ParamConstants.IMAGE_CENTER_TOLERANCE_DEFAULT));
+        params.setAutoCaptureEnabled(intent.getBooleanExtra(ParamConstants.AUTO_CAPTURE_ENABLED_NAME, ParamConstants.AUTO_CAPTURE_ENABLED_DEFAULT));
+        params.setTimeoutSecs(intent.getIntExtra(ParamConstants.TIMEOUT_SECS_NAME, ParamConstants.TIMEOUT_SECS_DEFAULT));
+        return params;
     }
 }

--- a/app/src/main/java/com/dimagi/biometric/fragments/FingerMatchFragment.java
+++ b/app/src/main/java/com/dimagi/biometric/fragments/FingerMatchFragment.java
@@ -1,5 +1,6 @@
 package com.dimagi.biometric.fragments;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -7,6 +8,8 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.dimagi.biometric.ParamManager;
+import com.dimagi.biometric.ParamConstants;
 import com.dimagi.biometric.viewmodels.FingerMatchViewModel;
 
 import java.util.ArrayList;
@@ -20,7 +23,6 @@ import ai.tech5.finger.utils.Finger;
 import ai.tech5.finger.utils.FingerCaptureResult;
 import ai.tech5.finger.utils.ImageConfiguration;
 import ai.tech5.finger.utils.ImageType;
-import ai.tech5.finger.utils.SegmentationMode;
 import ai.tech5.finger.utils.T5FingerCaptureController;
 import ai.tech5.finger.utils.T5FingerCapturedListener;
 
@@ -35,6 +37,7 @@ public class FingerMatchFragment extends BaseMatchFragment implements T5FingerCa
 
     @Override
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
         fingerMatchViewModel = new ViewModelProvider(requireActivity()).get(FingerMatchViewModel.class);
     }
 
@@ -45,10 +48,10 @@ public class FingerMatchFragment extends BaseMatchFragment implements T5FingerCa
 
         fingerCaptureController.showElipses(true);
         fingerCaptureController.setLivenessCheck(true);
-        fingerCaptureController.setDetectorThreshold(0.9f);
 
-        // TODO: Change this to segment for multiple fingers
-        fingerCaptureController.setSegmentationMode(SegmentationMode.SEGMENTATION_MODE_RIGHT_THUMB);
+        ParamManager params = getParams();
+        fingerCaptureController.setDetectorThreshold(params.getDetectorThreshold());
+        fingerCaptureController.setSegmentationMode(params.getSegmentationMode());
         fingerCaptureController.setCaptureMode(CaptureMode.CAPTURE_MODE_SELF);
         fingerCaptureController.setIsGetQuality(true);
 
@@ -67,7 +70,7 @@ public class FingerMatchFragment extends BaseMatchFragment implements T5FingerCa
         slapConfig.setIsCropImage(false);
 
         fingerCaptureController.setSlapImagesConfig(slapConfig);
-        fingerCaptureController.setTimeoutInSecs(20);
+        fingerCaptureController.setTimeoutInSecs(params.getTimeoutSecs());
         fingerCaptureController.captureFingers(requireContext(), this);
     }
 
@@ -105,5 +108,15 @@ public class FingerMatchFragment extends BaseMatchFragment implements T5FingerCa
     @Override
     public void onTimedout() {
         handleErrorMessage("Failed to capture finger image: Timed out");
+    }
+
+    @Override
+    protected ParamManager getParams() {
+        Intent intent = requireActivity().getIntent();
+        ParamManager params = new ParamManager();
+        params.setTimeoutSecs(intent.getIntExtra(ParamConstants.TIMEOUT_SECS_NAME, ParamConstants.TIMEOUT_SECS_DEFAULT));
+        params.setDetectorThreshold(intent.getFloatExtra(ParamConstants.DETECTOR_THRESHOLD_NAME, ParamConstants.DETECTOR_THRESHOLD_DEFAULT));
+        params.setSegmentationMode(intent.getStringExtra(ParamConstants.SEGMENTATION_MODE_NAME));
+        return params;
     }
 }

--- a/app/src/main/java/com/dimagi/biometric/viewmodels/BaseTemplateViewModel.java
+++ b/app/src/main/java/com/dimagi/biometric/viewmodels/BaseTemplateViewModel.java
@@ -73,9 +73,4 @@ public abstract class BaseTemplateViewModel extends AndroidViewModel {
         }
         return createRecord(templateList);
     }
-
-    public byte[] templateToBytes(BioCommon.MatcherTemplate template) {
-        return omniMatchViewModel.templateToBytes(template);
-    }
-
 }

--- a/app/src/main/java/com/dimagi/biometric/viewmodels/BaseTemplateViewModel.java
+++ b/app/src/main/java/com/dimagi/biometric/viewmodels/BaseTemplateViewModel.java
@@ -7,9 +7,14 @@ import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
+import com.dimagi.biometric.OmniMatchUtil;
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import org.commcare.commcaresupportlibrary.BiometricUtils;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import Tech5.OmniMatch.BioCommon;
 import Tech5.OmniMatch.Common;
@@ -30,7 +35,7 @@ public abstract class BaseTemplateViewModel extends AndroidViewModel {
 
     public abstract MatcherCommon.Record createRecord(List<BioCommon.MatcherTemplate> templates);
     protected final MutableLiveData<MatcherCommon.Record> activeRecord = new MutableLiveData<>();
-    protected OmniMatchViewModel omniMatchViewModel = null;
+    protected OmniMatchUtil omniMatchUtil = null;
 
     public void setActiveRecord(MatcherCommon.Record record) {
         activeRecord.postValue(record);
@@ -52,8 +57,21 @@ public abstract class BaseTemplateViewModel extends AndroidViewModel {
         super(application);
     }
 
-    public BioCommon.MatcherTemplate bytesToTemplate(byte[] templateData, int position) {
-        return omniMatchViewModel.bytesToTemplate(templateData, position);
+    public abstract BioCommon.MatcherTemplate bytesToTemplate(byte[] templateData, int position);
+
+    public MatcherCommon.Record getRecordFromTemplateStr(String rawTemplateStr) {
+        Map<BiometricUtils.BiometricIdentifier, byte[]> templateDataList = BiometricUtils.convertBase64StringTemplatesToByteArray(rawTemplateStr);
+        if (templateDataList == null) {
+            return null;
+        }
+
+        List<BioCommon.MatcherTemplate> templateList = new ArrayList<>();
+        for (Map.Entry<BiometricUtils.BiometricIdentifier, byte[]> templateItem : templateDataList.entrySet()) {
+            int position = OmniMatchUtil.getOmniPosition(templateItem.getKey());
+            BioCommon.MatcherTemplate template = bytesToTemplate(templateItem.getValue(), position);
+            templateList.add(template);
+        }
+        return createRecord(templateList);
     }
 
     public byte[] templateToBytes(BioCommon.MatcherTemplate template) {

--- a/app/src/main/java/com/dimagi/biometric/viewmodels/FaceMatchViewModel.java
+++ b/app/src/main/java/com/dimagi/biometric/viewmodels/FaceMatchViewModel.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.dimagi.biometric.OmniMatchUtil;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import java.io.IOException;
@@ -48,6 +49,7 @@ public class FaceMatchViewModel extends BaseTemplateViewModel {
                     .setFace(FaceCommon.FaceAlgorithm.DetFace_100Light).build()).setDebugMode(true).build();
             authMatcherInstance = authMatcherNative.CreateInstance(authMatcherConfiguration);
 
+            // TODO: Need to find a way to make gallery size configurable. CommCare could have more cases
             matcherNative = new MatcherNative();
             Matcher.MatcherConfiguration matcherConfiguration = Matcher.MatcherConfiguration.newBuilder()
                     .setAlgorithms(BioCommon.Algorithms.newBuilder()
@@ -70,13 +72,13 @@ public class FaceMatchViewModel extends BaseTemplateViewModel {
             Log.e(TAG, "Failed to init face view model: " + ex.getResultCode());
         }
 
-        omniMatchViewModel = new OmniMatchViewModel();
+        omniMatchUtil = new OmniMatchUtil();
     }
 
     @Override
     public void insertRecord(MatcherCommon.Record record, String id) {
         try {
-            omniMatchViewModel.insertRecord(matcherNative, matcherInstance, record, id);
+            omniMatchUtil.insertRecord(matcherNative, matcherInstance, record, id);
         } catch (OmniMatchException ex) {
             Log.e(TAG, "Failed to insert finger record: " + ex.getResultCode());
         }
@@ -85,7 +87,7 @@ public class FaceMatchViewModel extends BaseTemplateViewModel {
     @Override
     public float verifyRecord(MatcherCommon.Record record, String id) {
         try {
-            Matcher.RecordsResult result = omniMatchViewModel.verifyRecord(matcherNative, matcherInstance, record, id);
+            Matcher.RecordsResult result = omniMatchUtil.verifyRecord(matcherNative, matcherInstance, record, id);
             return result.getResultsList().get(0).getCandidate().getScores().getFace().getScore();
         } catch (OmniMatchException ex) {
             Log.e(TAG, "Failed to verify face record: " + ex.getResultCode());
@@ -98,7 +100,7 @@ public class FaceMatchViewModel extends BaseTemplateViewModel {
     @Override
     public Matcher.RecordsResult identifyRecord(MatcherCommon.Record record, float threshold, int maxCandidates) {
         try {
-            return omniMatchViewModel.identifyRecord(matcherNative, matcherInstance, record, threshold, maxCandidates);
+            return omniMatchUtil.identifyRecord(matcherNative, matcherInstance, record, threshold, maxCandidates);
         } catch(OmniMatchException ex) {
             Log.e(TAG, "Failed to identify face record: " + ex.getResultCode());
         } catch (IOException ex) {
@@ -110,7 +112,7 @@ public class FaceMatchViewModel extends BaseTemplateViewModel {
     @Override
     public BioCommon.MatcherTemplate createTemplate(byte[] image, int position, Common.ImageFormat imageFormat) {
         try {
-            return omniMatchViewModel.createFaceTemplate(templateCreatorNNNative, templateCreatorNNInstance, image, imageFormat);
+            return omniMatchUtil.createFaceTemplate(templateCreatorNNNative, templateCreatorNNInstance, image, imageFormat);
         } catch (OmniMatchException | InvalidProtocolBufferException ex) {
             Log.e(TAG, "Error creating face template");
         }
@@ -120,9 +122,17 @@ public class FaceMatchViewModel extends BaseTemplateViewModel {
     @Override
     public MatcherCommon.Record createRecord(List<BioCommon.MatcherTemplate> templates) {
         if (templates.size() > 0) {
-            return omniMatchViewModel.createFaceRecord(templates.get(0));
+            return omniMatchUtil.createFaceRecord(templates.get(0));
         }
         return null;
+    }
+
+    @Override
+    public BioCommon.MatcherTemplate bytesToTemplate(byte[] templateData, int position) {
+        if (omniMatchUtil == null) {
+            return null;
+        }
+        return omniMatchUtil.bytesToTemplate(templateData, position);
     }
 
     @Override

--- a/app/src/main/java/com/dimagi/biometric/viewmodels/FingerMatchViewModel.java
+++ b/app/src/main/java/com/dimagi/biometric/viewmodels/FingerMatchViewModel.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.dimagi.biometric.OmniMatchUtil;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import java.io.IOException;
@@ -36,7 +37,6 @@ public class FingerMatchViewModel extends BaseTemplateViewModel {
     private MatcherNative matcherNative = null;
     private MatcherInstance matcherInstance = null;
 
-    private OmniMatchViewModel omniMatchViewModel = null;
 
     public FingerMatchViewModel(@NonNull Application application) {
         super(application);
@@ -51,6 +51,7 @@ public class FingerMatchViewModel extends BaseTemplateViewModel {
                     .build()).setDebugMode(true).build();
             authMatcherInstance = authMatcherNative.CreateInstance(authMatcherConfiguration);
 
+            // TODO: Need to find a way to make gallery size configurable. CommCare could have more cases
             matcherNative = new MatcherNative();
             Matcher.MatcherConfiguration matcherConfiguration = Matcher.MatcherConfiguration.newBuilder()
                     .setAlgorithms(BioCommon.Algorithms.newBuilder()
@@ -73,12 +74,12 @@ public class FingerMatchViewModel extends BaseTemplateViewModel {
             Log.e(TAG, "Failed to init finger view model: " + ex.getResultCode());
         }
 
-        omniMatchViewModel = new OmniMatchViewModel();
+        omniMatchUtil = new OmniMatchUtil();
     }
 
     public void insertRecord(MatcherCommon.Record record, String id) {
         try {
-            omniMatchViewModel.insertRecord(matcherNative, matcherInstance, record, id);
+            omniMatchUtil.insertRecord(matcherNative, matcherInstance, record, id);
         } catch (OmniMatchException ex) {
             Log.e(TAG, "Failed to insert finger record: " + ex.getResultCode());
         }
@@ -87,7 +88,7 @@ public class FingerMatchViewModel extends BaseTemplateViewModel {
     @Override
     public float verifyRecord(MatcherCommon.Record record, String id) {
         try {
-            Matcher.RecordsResult result = omniMatchViewModel.verifyRecord(matcherNative, matcherInstance, record, id);
+            Matcher.RecordsResult result = omniMatchUtil.verifyRecord(matcherNative, matcherInstance, record, id);
             return result.getResultsList().get(0).getCandidate().getScores().getFinger().getScore();
         } catch (OmniMatchException ex) {
             Log.e(TAG, "Failed to verify finger record: " + ex.getResultCode());
@@ -100,7 +101,7 @@ public class FingerMatchViewModel extends BaseTemplateViewModel {
     @Override
     public Matcher.RecordsResult identifyRecord(MatcherCommon.Record record, float threshold, int maxCandidates) {
         try {
-            return omniMatchViewModel.identifyRecord(matcherNative, matcherInstance, record, threshold, maxCandidates);
+            return omniMatchUtil.identifyRecord(matcherNative, matcherInstance, record, threshold, maxCandidates);
         } catch(OmniMatchException ex) {
             Log.e(TAG, "Failed to identify finger record: " + ex.getResultCode());
         } catch (IOException ex) {
@@ -112,7 +113,7 @@ public class FingerMatchViewModel extends BaseTemplateViewModel {
     @Override
     public BioCommon.MatcherTemplate createTemplate(byte[] image, int position, Common.ImageFormat imageFormat) {
         try {
-            return omniMatchViewModel.createFingerTemplate(templateCreatorNNNative, templateCreatorNNInstance, image, position, imageFormat);
+            return omniMatchUtil.createFingerTemplate(templateCreatorNNNative, templateCreatorNNInstance, image, position, imageFormat);
         } catch (OmniMatchException | InvalidProtocolBufferException ex) {
             Log.e(TAG, "Failed to create finger template");
         }
@@ -121,7 +122,15 @@ public class FingerMatchViewModel extends BaseTemplateViewModel {
 
     @Override
     public MatcherCommon.Record createRecord(List<BioCommon.MatcherTemplate> templates) {
-        return omniMatchViewModel.createFingerRecord(templates);
+        return omniMatchUtil.createFingerRecord(templates);
+    }
+
+    @Override
+    public BioCommon.MatcherTemplate bytesToTemplate(byte[] templateData, int position) {
+        if (omniMatchUtil == null) {
+            return null;
+        }
+        return omniMatchUtil.bytesToTemplate(templateData, position);
     }
 
     @Override

--- a/app/src/main/java/com/dimagi/biometric/viewmodels/LicenseViewModel.java
+++ b/app/src/main/java/com/dimagi/biometric/viewmodels/LicenseViewModel.java
@@ -40,7 +40,8 @@ public class LicenseViewModel extends AndroidViewModel {
     public enum initStatus {
         FAIL,
         SUCCESS,
-        NO_NETWORK
+        NO_NETWORK,
+        NO_VALID_LICENSE,
     }
 
     public LicenseViewModel(@NonNull Application application) {
@@ -61,6 +62,9 @@ public class LicenseViewModel extends AndroidViewModel {
             boolean isSDKInitialized = loadLicense(context);
             if (isSDKInitialized) {
                 status.postValue(initStatus.SUCCESS);
+            } else {
+                status.postValue(initStatus.NO_VALID_LICENSE);
+                statusMessage.postValue(application.getResources().getString(R.string.license_validation_failed));
             }
         }).start();
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,9 @@
     <string name="omnimatch_failed">Failed to initialize OmniMatch</string>
     <string name="omnimatch_version">OmniMatch SDK v:4.5.1</string>
     <string name="connection_failed">No network available to initialize OmniMatch license</string>
+    <string name="license_validation_failed">Failed to validate OmniMatch license</string>
+    <string name="missing_case_id">Missing required \"case_id\" input parameter.</string>
+    <string name="missing_template_str">Missing required \"template\" input parameter.</string>
 
     <string name="permission_rationale">This app requires the Camera and CommCare Read permissions in order to do biometric capture and matching.</string>
     <string name="permission_settings">You will need to navigate to the app settings to enable the required permissions.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,7 +21,5 @@
     <string name="cancel">Cancel</string>
     <string name="retry">Retry</string>
 
-    <string name="go_to_settings">Go to settings</string>
-
     <string name="preference_file_key">perm_prefs</string>
 </resources>


### PR DESCRIPTION
The `OmniMatchViewModel` class is incorrectly named, as it is not a view model, and so has been renamed to `OmniMatchUtils`. Additionally, some helper methods have been implemented to aid in converting a template string to a OmniMatch record.