### PR TITLE
Fix params not loading

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,6 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     implementation 'org.commcarehq.commcare:support-library:12.4'
-    implementation 'com.google.code.gson:gson:2.8.7'
 
     def camerax_version = '1.2.3'
     implementation "androidx.camera:camera-core:$camerax_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     implementation 'org.commcarehq.commcare:support-library:12.4'
+    implementation 'com.google.code.gson:gson:2.8.7'
 
     def camerax_version = '1.2.3'
     implementation "androidx.camera:camera-core:$camerax_version"

--- a/app/src/main/java/com/dimagi/biometric/fragments/BaseMatchFragment.java
+++ b/app/src/main/java/com/dimagi/biometric/fragments/BaseMatchFragment.java
@@ -221,4 +221,30 @@ public abstract class BaseMatchFragment extends Fragment {
             }
         }
     }
+
+    protected Integer safeParseInteger(String num, int defaultVal) {
+        int outVal = defaultVal;
+        try {
+            outVal = Integer.parseInt(num);
+        } catch (NumberFormatException | NullPointerException ignored) {}
+        return outVal;
+    }
+
+    protected Float safeParseFloat(String num, float defaultVal) {
+        float outVal = defaultVal;
+        try {
+            outVal = Float.parseFloat(num);
+        } catch (NumberFormatException | NullPointerException ignored) {}
+        return outVal;
+    }
+
+    protected Boolean safeParseBool(String val, boolean defaultVal) {
+        boolean outVal = defaultVal;
+        try {
+            if (val.equalsIgnoreCase("true") || val.equalsIgnoreCase("false")) {
+                outVal = Boolean.parseBoolean(val);
+            }
+        } catch (NullPointerException ignored) {}
+        return outVal;
+    }
 }

--- a/app/src/main/java/com/dimagi/biometric/fragments/FaceMatchFragment.java
+++ b/app/src/main/java/com/dimagi/biometric/fragments/FaceMatchFragment.java
@@ -23,7 +23,7 @@ import ai.tech5.pheonix.capture.controller.AirsnapFaceThresholds;
 import ai.tech5.pheonix.capture.controller.FaceCaptureController;
 import ai.tech5.pheonix.capture.controller.FaceCaptureListener;
 
-public class FaceMatchFragment extends BaseMatchFragment implements FaceCaptureListener{
+public class FaceMatchFragment extends BaseMatchFragment implements FaceCaptureListener {
     private static final String TAG = "BIOMETRIC";
 
     protected FaceMatchViewModel faceMatchViewModel;
@@ -111,8 +111,8 @@ public class FaceMatchFragment extends BaseMatchFragment implements FaceCaptureL
                 intent.getStringExtra(ParamConstants.ROLL_NAME), ParamConstants.ROLL_DEFAULT
         ));
         params.setMask(safeParseFloat(
-            intent.getStringExtra(ParamConstants.MASK_NAME),
-            ParamConstants.MASK_DEFAULT
+                intent.getStringExtra(ParamConstants.MASK_NAME),
+                ParamConstants.MASK_DEFAULT
         ));
         params.setSunglasses(safeParseFloat(
                 intent.getStringExtra(ParamConstants.SUNGLASSES_NAME),

--- a/app/src/main/java/com/dimagi/biometric/fragments/FaceMatchFragment.java
+++ b/app/src/main/java/com/dimagi/biometric/fragments/FaceMatchFragment.java
@@ -100,16 +100,41 @@ public class FaceMatchFragment extends BaseMatchFragment implements FaceCaptureL
     protected ParamManager getParams() {
         Intent intent = requireActivity().getIntent();
         ParamManager params = new ParamManager();
-        params.setPitch(intent.getIntExtra(ParamConstants.PITCH_NAME, ParamConstants.PITCH_DEFAULT));
-        params.setYaw(intent.getIntExtra(ParamConstants.YAW_NAME, ParamConstants.YAW_DEFAULT));
-        params.setRoll(intent.getIntExtra(ParamConstants.ROLL_NAME, ParamConstants.ROLL_DEFAULT));
-        params.setMask(intent.getFloatExtra(ParamConstants.MASK_NAME, ParamConstants.MASK_DEFAULT));
-        params.setSunglasses(intent.getFloatExtra(ParamConstants.SUNGLASSES_NAME, ParamConstants.SUNGLASSES_DEFAULT));
-        params.setEyesClosed(intent.getFloatExtra(ParamConstants.EYES_CLOSED_NAME, ParamConstants.EYES_CLOSED_DEFAULT));
-        params.setBrisque(intent.getIntExtra(ParamConstants.BRISQUE_NAME, ParamConstants.BRISQUE_DEFAULT));
-        params.setImageCenterTolerance(intent.getFloatExtra(ParamConstants.IMAGE_CENTER_TOLERANCE_NAME, ParamConstants.IMAGE_CENTER_TOLERANCE_DEFAULT));
-        params.setAutoCaptureEnabled(intent.getBooleanExtra(ParamConstants.AUTO_CAPTURE_ENABLED_NAME, ParamConstants.AUTO_CAPTURE_ENABLED_DEFAULT));
-        params.setTimeoutSecs(intent.getIntExtra(ParamConstants.TIMEOUT_SECS_NAME, ParamConstants.TIMEOUT_SECS_DEFAULT));
+
+        params.setPitch(safeParseInteger(
+                intent.getStringExtra(ParamConstants.PITCH_NAME), ParamConstants.PITCH_DEFAULT
+        ));
+        params.setYaw(safeParseInteger(
+                intent.getStringExtra(ParamConstants.YAW_NAME), ParamConstants.YAW_DEFAULT
+        ));
+        params.setRoll(safeParseInteger(
+                intent.getStringExtra(ParamConstants.ROLL_NAME), ParamConstants.ROLL_DEFAULT
+        ));
+        params.setMask(safeParseFloat(
+            intent.getStringExtra(ParamConstants.MASK_NAME),
+            ParamConstants.MASK_DEFAULT
+        ));
+        params.setSunglasses(safeParseFloat(
+                intent.getStringExtra(ParamConstants.SUNGLASSES_NAME),
+                ParamConstants.SUNGLASSES_DEFAULT
+        ));
+        params.setEyesClosed(safeParseFloat(
+                intent.getStringExtra(ParamConstants.EYES_CLOSED_NAME),
+                ParamConstants.EYES_CLOSED_DEFAULT
+        ));
+        params.setBrisque(safeParseInteger(
+                intent.getStringExtra(ParamConstants.BRISQUE_NAME), ParamConstants.BRISQUE_DEFAULT
+        ));
+        params.setImageCenterTolerance(safeParseFloat(
+                intent.getStringExtra(ParamConstants.IMAGE_CENTER_TOLERANCE_NAME),
+                ParamConstants.IMAGE_CENTER_TOLERANCE_DEFAULT
+        ));
+        params.setTimeoutSecs(safeParseInteger(
+                intent.getStringExtra(ParamConstants.TIMEOUT_SECS_NAME), ParamConstants.TIMEOUT_SECS_DEFAULT
+        ));
+        params.setAutoCaptureEnabled(safeParseBool(
+                intent.getStringExtra(ParamConstants.AUTO_CAPTURE_ENABLED_NAME), ParamConstants.AUTO_CAPTURE_ENABLED_DEFAULT
+        ));
         return params;
     }
 }

--- a/app/src/main/java/com/dimagi/biometric/fragments/FingerMatchFragment.java
+++ b/app/src/main/java/com/dimagi/biometric/fragments/FingerMatchFragment.java
@@ -114,8 +114,15 @@ public class FingerMatchFragment extends BaseMatchFragment implements T5FingerCa
     protected ParamManager getParams() {
         Intent intent = requireActivity().getIntent();
         ParamManager params = new ParamManager();
-        params.setTimeoutSecs(intent.getIntExtra(ParamConstants.TIMEOUT_SECS_NAME, ParamConstants.TIMEOUT_SECS_DEFAULT));
-        params.setDetectorThreshold(intent.getFloatExtra(ParamConstants.DETECTOR_THRESHOLD_NAME, ParamConstants.DETECTOR_THRESHOLD_DEFAULT));
+
+        params.setTimeoutSecs(safeParseInteger(
+                intent.getStringExtra(ParamConstants.TIMEOUT_SECS_NAME),
+                ParamConstants.TIMEOUT_SECS_DEFAULT
+        ));
+        params.setDetectorThreshold(safeParseFloat(
+                intent.getStringExtra(ParamConstants.DETECTOR_THRESHOLD_NAME),
+                ParamConstants.DETECTOR_THRESHOLD_DEFAULT
+        ));
         params.setSegmentationMode(intent.getStringExtra(ParamConstants.SEGMENTATION_MODE_NAME));
         return params;
     }


### PR DESCRIPTION
Link to ticket [here](https://dimagi-dev.atlassian.net/browse/SC-3142).

Input parameters were incorrectly being retreived using `intent.getIntExtra()` or `intent.getFloatExtra()` which resulted in the default values always being applied. The reason for this is that the incoming parameters from CommCare are in `String` format, and so need to be correctly parsed.

This PR adds helper functions for safely parsing float/int/boolean strings. After the parameters have been safely parsed, they are then passed along to the `ParamManager` class.

