### PR TITLE
Add 'no fingerprint detected message'

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,6 @@
     <string name="confirm">Confirm</string>
     <string name="cancel">Cancel</string>
     <string name="retry">Retry</string>
-
+    <string name="label_frame_hand">No Finger(s) detected</string>
     <string name="preference_file_key">perm_prefs</string>
 </resources>


### PR DESCRIPTION
For some reason adding the Airsnap library files to gitignore did not add it, so I didn't bother further