### PR TITLE
Handle invidiual templates

### DIFF
--- a/app/src/main/java/com/dimagi/biometric/OmniMatchUtil.java
+++ b/app/src/main/java/com/dimagi/biometric/OmniMatchUtil.java
@@ -3,7 +3,7 @@ package com.dimagi.biometric;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
-import org.commcare.commcaresupportlibrary.BiometricUtils;
+import org.commcare.commcaresupportlibrary.identity.BiometricIdentifier;
 
 import java.io.IOException;
 import java.util.List;
@@ -100,10 +100,8 @@ public class OmniMatchUtil {
 
         if (createTemplateResponse.getResultCode() == Common.ResultCode.Success) {
             TemplateCreatorCommon.CreateTemplateResult createTemplateResult = createTemplateResponse.getResultsList().get(0);
-            String batchIdentifier = createTemplateResult.getTemplateResult().getBatchIdentifier().getId();
-            int fingerPosition = Integer.parseInt(batchIdentifier);
             BioCommon.Template template = createTemplateResult.getTemplateResult().getTemplate();
-            return createMatcherTemplate(template, fingerPosition);
+            return createMatcherTemplate(template, position);
         }
         return null;
     }
@@ -134,30 +132,30 @@ public class OmniMatchUtil {
         return matcherTemplateBuilder.build();
     }
 
-    public static BiometricUtils.BiometricIdentifier getBiometricIdentifierFromPosition(FingerCommon.NistFingerPosition fingerPosition) {
+    public static BiometricIdentifier getBiometricIdentifierFromPosition(FingerCommon.NistFingerPosition fingerPosition) {
         switch (fingerPosition) {
             case LeftIndexFinger:
-                return BiometricUtils.BiometricIdentifier.LEFT_INDEX_FINGER;
+                return BiometricIdentifier.LEFT_INDEX_FINGER;
             case LeftMiddleFinger:
-                return BiometricUtils.BiometricIdentifier.LEFT_MIDDLE_FINGER;
+                return BiometricIdentifier.LEFT_MIDDLE_FINGER;
             case LeftRingFinger:
-                return BiometricUtils.BiometricIdentifier.LEFT_RING_FINGER;
+                return BiometricIdentifier.LEFT_RING_FINGER;
             case LeftLittleFinger:
-                return BiometricUtils.BiometricIdentifier.LEFT_PINKY_FINGER;
+                return BiometricIdentifier.LEFT_PINKY_FINGER;
             case LeftThumb:
-                return BiometricUtils.BiometricIdentifier.LEFT_THUMB;
+                return BiometricIdentifier.LEFT_THUMB;
             case RightIndexFinger:
-                return BiometricUtils.BiometricIdentifier.RIGHT_INDEX_FINGER;
+                return BiometricIdentifier.RIGHT_INDEX_FINGER;
             case RightMiddleFinger:
-                return BiometricUtils.BiometricIdentifier.RIGHT_MIDDLE_FINGER;
+                return BiometricIdentifier.RIGHT_MIDDLE_FINGER;
             case RightRingFinger:
-                return BiometricUtils.BiometricIdentifier.RIGHT_RING_FINGER;
+                return BiometricIdentifier.RIGHT_RING_FINGER;
             case RightLittleFinger:
-                return BiometricUtils.BiometricIdentifier.RIGHT_PINKY_FINGER;
+                return BiometricIdentifier.RIGHT_PINKY_FINGER;
             case RightThumb:
-                return BiometricUtils.BiometricIdentifier.RIGHT_THUMB;
+                return BiometricIdentifier.RIGHT_THUMB;
             default:
-                return BiometricUtils.BiometricIdentifier.FACE;
+                return BiometricIdentifier.FACE;
         }
     }
 
@@ -165,8 +163,8 @@ public class OmniMatchUtil {
      * Gets the finger position that OmniMatch uses to index fingers. This is necessary as the ordinals
      * from BiometricIdentifier are different and so, using these will cause a position error when using OmniMatch
      */
-    public static int getOmniPosition(BiometricUtils.BiometricIdentifier identifier) {
-        if (identifier == BiometricUtils.BiometricIdentifier.FACE) {
+    public static int getOmniPosition(BiometricIdentifier identifier) {
+        if (identifier == BiometricIdentifier.FACE) {
             return 0;
         }
         return identifier.ordinal() + 1;

--- a/app/src/main/java/com/dimagi/biometric/ParamConstants.java
+++ b/app/src/main/java/com/dimagi/biometric/ParamConstants.java
@@ -28,8 +28,6 @@ public class ParamConstants {
     public static final SegmentationMode SEGMENTATION_MODE_DEFAULT = SegmentationMode.SEGMENTATION_MODE_LEFT_AND_RIGHT_THUMBS;
     public static final String TIMEOUT_SECS_NAME = "timeout_secs";
     public static final int TIMEOUT_SECS_DEFAULT = 30;
-    public static final String TEMPLATE_PROP_NAME = "template_prop_name";
-    public static final String TEMPLATE_PROP_NAME_DEFAULT = "bio_template";
     public static final String ACCEPTANCE_THRESHOLD_NAME = "acceptance_threshold";
     public static final float ACCEPTANCE_THRESHOLD_DEFAULT = 4.0f;
 }

--- a/app/src/main/java/com/dimagi/biometric/activities/EnrollActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/EnrollActivity.java
@@ -3,7 +3,7 @@ package com.dimagi.biometric.activities;
 import com.dimagi.biometric.OmniMatchUtil;
 import com.dimagi.biometric.R;
 
-import org.commcare.commcaresupportlibrary.BiometricUtils;
+import org.commcare.commcaresupportlibrary.identity.BiometricIdentifier;
 import org.commcare.commcaresupportlibrary.identity.IdentityResponseBuilder;
 
 import java.util.ArrayList;
@@ -17,10 +17,10 @@ import Tech5.OmniMatch.MatcherCommon;
 public class EnrollActivity extends BaseActivity {
     @Override
     protected void onCaptureSuccess(MatcherCommon.Record activeRecord) {
-        Map<BiometricUtils.BiometricIdentifier, byte[]> templateDataList = new HashMap<>();
+        Map<BiometricIdentifier, byte[]> templateDataList = new HashMap<>();
         if (biometricType == BioCommon.BioType.Face) {
             byte[] templateData = activeRecord.getFace().getTemplateData().getData().toByteArray();
-            templateDataList.put(BiometricUtils.BiometricIdentifier.FACE, templateData);
+            templateDataList.put(BiometricIdentifier.FACE, templateData);
         } else {
             for (BioCommon.MatcherTemplate template : activeRecord.getNnFingersList()) {
                 byte[] templateData = template.getTemplateData().getData().toByteArray();
@@ -35,7 +35,7 @@ public class EnrollActivity extends BaseActivity {
 
     @Override
     protected void onCaptureCancelled() {
-        Map<BiometricUtils.BiometricIdentifier, byte[]> templateDataList = new HashMap<>();
+        Map<BiometricIdentifier, byte[]> templateDataList = new HashMap<>();
         IdentityResponseBuilder.registrationResponse(caseId, templateDataList).finalizeResponse(this);
     }
 

--- a/app/src/main/java/com/dimagi/biometric/activities/SearchActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/SearchActivity.java
@@ -23,18 +23,12 @@ import Tech5.OmniMatch.Matcher;
 import Tech5.OmniMatch.MatcherCommon;
 
 public class SearchActivity extends BaseActivity {
-    private String templatePropName = ParamConstants.TEMPLATE_PROP_NAME_DEFAULT;
     private float acceptanceThreshold = ParamConstants.ACCEPTANCE_THRESHOLD_DEFAULT;
-    private final String TAG = "BIOMETRIC";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Intent intent = getIntent();
-        String propName = intent.getStringExtra(ParamConstants.TEMPLATE_PROP_NAME);
-        if (propName != null) {
-            templatePropName = propName;
-        }
         acceptanceThreshold = intent.getFloatExtra(
                 ParamConstants.ACCEPTANCE_THRESHOLD_NAME, ParamConstants.ACCEPTANCE_THRESHOLD_DEFAULT
         );

--- a/app/src/main/java/com/dimagi/biometric/activities/SearchActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/SearchActivity.java
@@ -49,7 +49,9 @@ public class SearchActivity extends BaseActivity {
 
     @Override
     protected void onCaptureCancelled() {
-        finishWorkflow(new ArrayList<>());
+        ArrayList<IdentificationMatch> identifications = new ArrayList<>();
+        identifications.add(new IdentificationMatch(caseId, new MatchResult(0, MatchStrength.ONE_STAR)));
+        IdentityResponseBuilder.identificationResponse(identifications).finalizeResponse(this);
     }
 
     private void fetchCaseData() {
@@ -72,15 +74,6 @@ public class SearchActivity extends BaseActivity {
                 Log.e(TAG, "Null pointer exception on creating record: " + e);
             }
         }
-    }
-
-    private void finishWorkflow(ArrayList<IdentificationMatch> identifications) {
-        if (identifications.size() == 0) {
-            identifications.add(
-                    new IdentificationMatch(caseId, new MatchResult(0, MatchStrength.ONE_STAR))
-            );
-        }
-        IdentityResponseBuilder.identificationResponse(identifications).finalizeResponse(this);
     }
 
     private ArrayList<IdentificationMatch> getIdentificationsFromResult(Matcher.RecordsResult result) {

--- a/app/src/main/java/com/dimagi/biometric/activities/VerifyActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/VerifyActivity.java
@@ -13,12 +13,9 @@ import Tech5.OmniMatch.MatcherCommon;
 public class VerifyActivity extends BaseActivity {
     @Override
     protected void onCaptureSuccess(MatcherCommon.Record activeRecord) {
-        if (templateStr == null) {
-            return;
-        }
-        MatcherCommon.Record caseRecord = templateViewModel.getRecordFromTemplateStr(templateStr);
-        if (caseRecord != null) {
-            templateViewModel.insertRecord(caseRecord, caseId);
+        templateRecord = parseBiometricTemplates();
+        if (templateRecord != null) {
+            templateViewModel.insertRecord(templateRecord, caseId);
         }
         float score = templateViewModel.verifyRecord(activeRecord, caseId);
         finalizeResponse(score);
@@ -42,9 +39,6 @@ public class VerifyActivity extends BaseActivity {
         ArrayList<String> errors = new ArrayList<>();
         if (caseId == null) {
             errors.add(getText(R.string.missing_case_id).toString());
-        }
-        if (templateStr == null) {
-            errors.add(getText(R.string.missing_template_str).toString());
         }
         return errors;
     }

--- a/app/src/main/java/com/dimagi/biometric/viewmodels/BaseTemplateViewModel.java
+++ b/app/src/main/java/com/dimagi/biometric/viewmodels/BaseTemplateViewModel.java
@@ -6,15 +6,14 @@ import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import android.util.Base64;
 
 import com.dimagi.biometric.OmniMatchUtil;
 import com.google.protobuf.InvalidProtocolBufferException;
 
-import org.commcare.commcaresupportlibrary.BiometricUtils;
+import org.commcare.commcaresupportlibrary.identity.BiometricIdentifier;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import Tech5.OmniMatch.BioCommon;
 import Tech5.OmniMatch.Common;
@@ -59,18 +58,9 @@ public abstract class BaseTemplateViewModel extends AndroidViewModel {
 
     public abstract BioCommon.MatcherTemplate bytesToTemplate(byte[] templateData, int position);
 
-    public MatcherCommon.Record getRecordFromTemplateStr(String rawTemplateStr) {
-        Map<BiometricUtils.BiometricIdentifier, byte[]> templateDataList = BiometricUtils.convertBase64StringTemplatesToByteArray(rawTemplateStr);
-        if (templateDataList == null) {
-            return null;
-        }
-
-        List<BioCommon.MatcherTemplate> templateList = new ArrayList<>();
-        for (Map.Entry<BiometricUtils.BiometricIdentifier, byte[]> templateItem : templateDataList.entrySet()) {
-            int position = OmniMatchUtil.getOmniPosition(templateItem.getKey());
-            BioCommon.MatcherTemplate template = bytesToTemplate(templateItem.getValue(), position);
-            templateList.add(template);
-        }
-        return createRecord(templateList);
+    public BioCommon.MatcherTemplate getMatcherTemplateFromStr(String rawTemplateStr, BiometricIdentifier bioIdentifier) {
+        byte[] templateData = Base64.decode(rawTemplateStr, Base64.DEFAULT);
+        int position = OmniMatchUtil.getOmniPosition(bioIdentifier);
+        return bytesToTemplate(templateData, position);
     }
 }


### PR DESCRIPTION
This PR incorporates the necessary changes to handle individual biometric templates. Previously, these have all been saved under a single case property, but now each biometric finger is saved as a separate case property and needs to be handled as such by the biometric application.