### PR TITLE
add dependencies for firebase

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,8 @@
 plugins {
     id 'com.android.application'
+
+    id 'com.google.gms.google-services'
+    id 'com.google.firebase.crashlytics'
 }
 
 android {
@@ -78,4 +81,8 @@ dependencies {
     implementation(project(path: ':AirsnapFinger'))
     implementation(project(path: ':AirsnapFingerUI'))
     implementation(project(path: ':OmniMatch'))
+
+    implementation(platform("com.google.firebase:firebase-bom:32.3.1"))
+    implementation("com.google.firebase:firebase-crashlytics")
+    implementation("com.google.firebase:firebase-analytics")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,4 +3,7 @@ plugins {
     id 'com.android.application' version '8.0.1' apply false
     id 'com.android.library' version '8.0.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
+    
+    id 'com.google.gms.google-services' version '4.3.15' apply false
+    id 'com.google.firebase.crashlytics' version '2.9.9' apply false
 }


### PR DESCRIPTION
Adds in necessary dependencies to integrate firebase crashlytics to the biometric application. The `google_services.json` file has been excluded and will need to be separately pulled in when setting up a developer environment.