### PR TITLE
Allow camera selection during face capture

### DIFF
--- a/app/src/main/java/com/dimagi/biometric/ParamConstants.java
+++ b/app/src/main/java/com/dimagi/biometric/ParamConstants.java
@@ -30,4 +30,7 @@ public class ParamConstants {
     public static final int TIMEOUT_SECS_DEFAULT = 30;
     public static final String ACCEPTANCE_THRESHOLD_NAME = "acceptance_threshold";
     public static final float ACCEPTANCE_THRESHOLD_DEFAULT = 4.0f;
+    // This parameter is only applicable to face capture
+    public static final String USE_BACK_CAMERA_NAME = "use_back_camera";
+    public static final boolean USE_BACK_CAMERA_DEFAULT = false;
 }

--- a/app/src/main/java/com/dimagi/biometric/ParamManager.java
+++ b/app/src/main/java/com/dimagi/biometric/ParamManager.java
@@ -20,6 +20,7 @@ public class ParamManager {
     private float detectorThreshold = ParamConstants.DETECTOR_THRESHOLD_DEFAULT;
     private int timeoutSecs = ParamConstants.TIMEOUT_SECS_DEFAULT;
     private SegmentationMode segmentationMode = ParamConstants.SEGMENTATION_MODE_DEFAULT;
+    private boolean useBackCamera = ParamConstants.USE_BACK_CAMERA_DEFAULT;
 
     private int clampValue(int val, int min, int max) {
         return Math.max(min, Math.min(max, val));
@@ -151,4 +152,13 @@ public class ParamManager {
     public SegmentationMode getSegmentationMode() {
         return segmentationMode;
     }
+
+    public void setUseBackCamera(boolean useBackCamera) {
+        this.useBackCamera = useBackCamera;
+    }
+
+    public boolean getUseBackCamera() {
+        return useBackCamera;
+    }
+
 }

--- a/app/src/main/java/com/dimagi/biometric/fragments/FaceMatchFragment.java
+++ b/app/src/main/java/com/dimagi/biometric/fragments/FaceMatchFragment.java
@@ -43,7 +43,7 @@ public class FaceMatchFragment extends BaseMatchFragment implements FaceCaptureL
         ParamManager params = getParams();
 
         FaceCaptureController controller = FaceCaptureController.getInstance();
-        controller.setUseBackCamera(false);
+        controller.setUseBackCamera(params.getUseBackCamera());
         controller.setAutoCapture(params.getAutoCaptureEnabled());
         controller.setCaptureTimeoutInSecs(params.getTimeoutSecs());
 
@@ -134,6 +134,9 @@ public class FaceMatchFragment extends BaseMatchFragment implements FaceCaptureL
         ));
         params.setAutoCaptureEnabled(safeParseBool(
                 intent.getStringExtra(ParamConstants.AUTO_CAPTURE_ENABLED_NAME), ParamConstants.AUTO_CAPTURE_ENABLED_DEFAULT
+        ));
+        params.setUseBackCamera(safeParseBool(
+                intent.getStringExtra(ParamConstants.USE_BACK_CAMERA_NAME), ParamConstants.USE_BACK_CAMERA_DEFAULT
         ));
         return params;
     }


### PR DESCRIPTION
The Tech5 SDK default camera for capturing facial biometrics is the front camera, this PR adds a new parameter to indicate that the back camera should be used. This change is needed because users are expected to capture the beneficiaries' biometrics, this parameter will allow them to switch to the back camera.
To configure, add an extra `use_back_camera` and set the value to `true`:
![image](https://github.com/dimagi/biometric-android/assets/19228119/3ceab9de-d7b9-43aa-a6ee-ea9f814de0a3)

