### PR TITLE
Exclude blank biometrics from Search workflow results

### DIFF
--- a/app/src/main/java/com/dimagi/biometric/activities/SearchActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/SearchActivity.java
@@ -86,7 +86,7 @@ public class SearchActivity extends BaseActivity {
         ArrayList<BioCommon.MatcherTemplate> templateList = new ArrayList<>();
         for (BiometricIdentifier bioId : bioIds) {
             String templateStr = CaseUtils.getCaseProperty(this, caseIdProp, bioId.getCalloutResponseKey());
-            if (templateStr == null) {
+            if (templateStr == null || templateStr.equals("")) {
                 continue;
             }
 


### PR DESCRIPTION
This PR fixes a small issue in the biometric search workflow which causes the app to crash when a blank (not null) biometric is found. Here's the error:
```
#00 pc 00021026  /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/lib/arm/libTech5_Matcher.so (Tech5_core::check_template(Tech5_core::Algorithm const&, Tech5_core::T5_record*)+154) (BuildId: 122c8b1a83408b4d82a6c59abb3c735bed512c68)
13:58:59.509  A        #01 pc 000210f7  /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/lib/arm/libTech5_Matcher.so (Tech5_core::RealMatcher::prepare_insert(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const*, Tech5_core::T5_record*, Tech5_core::Item_address*, Tech5_core::Item_address*, Tech5_core::Item_address*)+38) (BuildId: 122c8b1a83408b4d82a6c59abb3c735bed512c68)
13:58:59.509  A        #02 pc 000212f9  /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/lib/arm/libTech5_Matcher.so (Tech5_core::RealMatcher::insert_record(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const*, Tech5_core::T5_record*)+144) (BuildId: 122c8b1a83408b4d82a6c59abb3c735bed512c68)
13:58:59.509  A        #03 pc 0004dd8b  /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/lib/arm/libTech5_MatcherProto.so (Tech5::OmniMatch::RealProtoMatcher::insert_record(Tech5::OmniMatch::InsertRecordRequest const&)+110) (BuildId: 955a48d344f68287203f080761d6f5f525bcc524)
13:58:59.509  A        #04 pc 00097719  /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/lib/arm/libTech5OmniMatchSDKBaseWrapper.so (Tech5::OmniMatch::ResultCode InvokeMethodRequest<Tech5::OmniMatch::Matcher, Tech5::OmniMatch::InsertRecordRequest>(void*, unsigned char*, unsigned int, Tech5::OmniMatch::ResultCode (Tech5::OmniMatch::Matcher::*)(Tech5::OmniMatch::InsertRecordRequest const&))+60) (BuildId: 6ac8902737874c50161146fae2ec2efda4e02cfe)
13:58:59.509  A        #05 pc 000976d7  /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/lib/arm/libTech5OmniMatchSDKBaseWrapper.so (Matcher_InsertRecord+10) (BuildId: 6ac8902737874c50161146fae2ec2efda4e02cfe)
13:58:59.509  A        #06 pc 00093003  /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/lib/arm/libTech5OmniMatchSDKJNI.so (Java_Tech5_OmniMatch_JNI_Matchers_MatcherNative_InsertRecordNative+98) (BuildId: 661ff31905f12932e745f83bf353d7abe8bdd132)
13:58:59.510  A        #15 pc 000d3b64  [anon:dalvik-classes2.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk!classes2.dex] (Tech5.OmniMatch.JNI.Matchers.MatcherNative.InsertRecord+0)
13:58:59.510  A        #21 pc 000023d8  [anon:dalvik-classes5.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk!classes5.dex] (com.dimagi.biometric.OmniMatchUtil.insertRecord+0)
13:58:59.510  A        #27 pc 0000344c  [anon:dalvik-classes5.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk!classes5.dex] (com.dimagi.biometric.viewmodels.FingerMatchViewModel.insertRecord+0)
13:58:59.510  A        #33 pc 00001bb4  /data/data/com.dimagi.biometric/code_cache/.overlay/base.apk/classes4.dex (com.dimagi.biometric.activities.SearchActivity.processCaseData+0)
13:58:59.510  A        #39 pc 00001aa0  /data/data/com.dimagi.biometric/code_cache/.overlay/base.apk/classes4.dex (com.dimagi.biometric.activities.SearchActivity.fetchCaseData+0)
13:58:59.510  A        #45 pc 00001b38  /data/data/com.dimagi.biometric/code_cache/.overlay/base.apk/classes4.dex (com.dimagi.biometric.activities.SearchActivity.onCaptureSuccess+0)
13:58:59.511  A        #51 pc 00001590  /data/data/com.dimagi.biometric/code_cache/.overlay/base.apk/classes4.dex (com.dimagi.biometric.activities.BaseActivity.lambda$initTemplateViewModel$1$com-dimagi-biometric-activities-BaseActivity+0)
13:58:59.511  A        #57 pc 00001114  /data/data/com.dimagi.biometric/code_cache/.overlay/base.apk/classes4.dex (com.dimagi.biometric.activities.BaseActivity$$ExternalSyntheticLambda3.onChanged+0)
13:58:59.511  A        #63 pc 003480ac  [anon:dalvik-classes.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk] (androidx.lifecycle.LiveData.considerNotify+0)
13:58:59.511  A        #69 pc 00348100  [anon:dalvik-classes.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk] (androidx.lifecycle.LiveData.dispatchingValue+0)
13:58:59.511  A        #75 pc 00347d64  [anon:dalvik-classes.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk] (androidx.lifecycle.LiveData$ObserverWrapper.activeStateChanged+0)
13:58:59.512  A        #81 pc 00347cbc  [anon:dalvik-classes.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk] (androidx.lifecycle.LiveData$LifecycleBoundObserver.onStateChanged+0)
13:58:59.512  A        #87 pc 00346c30  [anon:dalvik-classes.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk] (androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent+0)
13:58:59.512  A        #93 pc 003471f8  [anon:dalvik-classes.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk] (androidx.lifecycle.LifecycleRegistry.forwardPass+0)
13:58:59.512  A        #99 pc 003474e0  [anon:dalvik-classes.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk] (androidx.lifecycle.LifecycleRegistry.sync+0)
13:58:59.512  A        #105 pc 00347360  [anon:dalvik-classes.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk] (androidx.lifecycle.LifecycleRegistry.moveToState+0)
13:58:59.512  A        #111 pc 00347300  [anon:dalvik-classes.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk] (androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent+0)
13:58:59.513  A        #117 pc 00349b0c  [anon:dalvik-classes.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk] (androidx.lifecycle.ReportFragment$Companion.dispatch$lifecycle_runtime_release+0)
13:58:59.513  A        #123 pc 00349d4c  [anon:dalvik-classes.dex extracted in memory from /data/app/~~c5hntTCGc_ShGZ058OPXCA==/com.dimagi.biometric-5dlxqigZFSw-JMJPozn8iA==/base.apk] (androidx.lifecycle.ReportFragment$LifecycleCallbacks.onActivityPostStarted+0)
```