### PR TITLE
Include Project Id in license validation request

### DIFF
--- a/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
@@ -243,6 +243,9 @@ public abstract class BaseActivity extends AppCompatActivity {
         if (caseId == null) {
             errors.add(getText(R.string.missing_case_id).toString());
         }
+        if (projectId == null) {
+            errors.add(getText(R.string.missing_project_id).toString());
+        }
         return errors;
     }
 }

--- a/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
@@ -38,6 +38,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     final protected String CASE_ID_PARAM = "case_id";
     final protected String BIOMETRIC_TYPE_PARAM = "biometric_type";
     final protected String TEMPLATE_PARAM = "template";
+    final protected String PROJECT_ID_PARAM = "project_id";
     protected BioCommon.BioType biometricType;
     protected String caseId;
     protected String templateStr;
@@ -47,6 +48,7 @@ public abstract class BaseActivity extends AppCompatActivity {
 
     private LicenseViewModel licenseViewModel;
     protected BaseTemplateViewModel templateViewModel;
+    protected String projectId;
 
     protected abstract void onCaptureSuccess(MatcherCommon.Record activeRecord);
     protected abstract void onCaptureCancelled();
@@ -92,6 +94,7 @@ public abstract class BaseActivity extends AppCompatActivity {
         }
         caseId = intent.getStringExtra(CASE_ID_PARAM);
         templateStr = intent.getStringExtra(TEMPLATE_PARAM);
+        projectId = intent.getStringExtra(PROJECT_ID_PARAM);
     }
 
     protected MatcherCommon.Record parseBiometricTemplates() {

--- a/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
@@ -246,8 +246,14 @@ public abstract class BaseActivity extends AppCompatActivity {
         }
         if (projectId == null) {
             errors.add(getText(R.string.missing_project_id).toString());
+        } else if (hasSpaces(projectId)) {
+            errors.add(getText(R.string.invalid_project_id).toString());
         }
         return errors;
+    }
+
+    private boolean hasSpaces(String text) {
+        return text.contains(" ");
     }
 }
 

--- a/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
@@ -35,6 +35,7 @@ import Tech5.OmniMatch.MatcherCommon;
 
 public abstract class BaseActivity extends AppCompatActivity {
 
+    public static final String ERROR_MESSAGES_BUNDLE_KEY = "errors";
     final protected String CASE_ID_PARAM = "case_id";
     final protected String BIOMETRIC_TYPE_PARAM = "biometric_type";
     final protected String TEMPLATE_PARAM = "template";
@@ -129,7 +130,7 @@ public abstract class BaseActivity extends AppCompatActivity {
         if (errors.size() > 0) {
             Bundle args = new Bundle();
             String errorStr = createErrorStr(errors);
-            args.putString("errors", errorStr);
+            args.putString(ERROR_MESSAGES_BUNDLE_KEY, errorStr);
             fragment.setArguments(args);
         }
     }

--- a/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
@@ -52,7 +52,6 @@ public abstract class BaseActivity extends AppCompatActivity {
 
     protected abstract void onCaptureSuccess(MatcherCommon.Record activeRecord);
     protected abstract void onCaptureCancelled();
-    protected abstract ArrayList<String> validateRequiredParams();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -237,6 +236,14 @@ public abstract class BaseActivity extends AppCompatActivity {
             errorStr.append(error).append("\n");
         }
         return errorStr.toString();
+    }
+
+    private ArrayList<String> validateRequiredParams() {
+        ArrayList<String> errors = new ArrayList<>();
+        if (caseId == null) {
+            errors.add(getText(R.string.missing_case_id).toString());
+        }
+        return errors;
     }
 }
 

--- a/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/BaseActivity.java
@@ -68,7 +68,7 @@ public abstract class BaseActivity extends AppCompatActivity {
         Button retryButton = findViewById(R.id.retry_init_button);
         retryButton.setOnClickListener(v -> {
             toggleRetryButton(false);
-            licenseViewModel.initSDK(this);
+            licenseViewModel.initSDK(this, projectId);
         });
 
         getIntentParams();
@@ -184,7 +184,7 @@ public abstract class BaseActivity extends AppCompatActivity {
             }
         });
 
-        licenseViewModel.initSDK(BaseActivity.this);
+        licenseViewModel.initSDK(BaseActivity.this, projectId);
     }
 
     protected MatchStrength getMatchStrength(float score) {

--- a/app/src/main/java/com/dimagi/biometric/activities/EnrollActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/EnrollActivity.java
@@ -38,13 +38,4 @@ public class EnrollActivity extends BaseActivity {
         Map<BiometricIdentifier, byte[]> templateDataList = new HashMap<>();
         IdentityResponseBuilder.registrationResponse(caseId, templateDataList).finalizeResponse(this);
     }
-
-    @Override
-    protected ArrayList<String> validateRequiredParams() {
-        ArrayList<String> errors = new ArrayList<>();
-        if (caseId == null) {
-            errors.add(getText(R.string.missing_case_id).toString());
-        }
-        return errors;
-    }
 }

--- a/app/src/main/java/com/dimagi/biometric/activities/EnrollActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/EnrollActivity.java
@@ -1,12 +1,10 @@
 package com.dimagi.biometric.activities;
 
 import com.dimagi.biometric.OmniMatchUtil;
-import com.dimagi.biometric.R;
 
 import org.commcare.commcaresupportlibrary.identity.BiometricIdentifier;
 import org.commcare.commcaresupportlibrary.identity.IdentityResponseBuilder;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/app/src/main/java/com/dimagi/biometric/activities/SearchActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/SearchActivity.java
@@ -1,8 +1,11 @@
 package com.dimagi.biometric.activities;
 
+import android.content.Intent;
+import android.database.Cursor;
+import android.os.Bundle;
+
 import com.dimagi.biometric.OmniMatchUtil;
 import com.dimagi.biometric.ParamConstants;
-import com.dimagi.biometric.R;
 
 import org.commcare.commcaresupportlibrary.CaseUtils;
 import org.commcare.commcaresupportlibrary.identity.BiometricIdentifier;
@@ -10,10 +13,6 @@ import org.commcare.commcaresupportlibrary.identity.IdentityResponseBuilder;
 import org.commcare.commcaresupportlibrary.identity.model.IdentificationMatch;
 import org.commcare.commcaresupportlibrary.identity.model.MatchResult;
 import org.commcare.commcaresupportlibrary.identity.model.MatchStrength;
-
-import android.content.Intent;
-import android.database.Cursor;
-import android.os.Bundle;
 
 import java.util.ArrayList;
 

--- a/app/src/main/java/com/dimagi/biometric/activities/SearchActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/SearchActivity.java
@@ -124,13 +124,4 @@ public class SearchActivity extends BaseActivity {
         }
         return identifications;
     }
-
-    @Override
-    protected ArrayList<String> validateRequiredParams() {
-        ArrayList<String> errors = new ArrayList<>();
-        if (caseId == null) {
-            errors.add(getText(R.string.missing_case_id).toString());
-        }
-        return errors;
-    }
 }

--- a/app/src/main/java/com/dimagi/biometric/activities/VerifyActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/VerifyActivity.java
@@ -33,13 +33,4 @@ public class VerifyActivity extends BaseActivity {
                 caseId, new MatchResult(confidencePercentage, matchStrength)
         ).finalizeResponse(this);
     }
-
-    @Override
-    protected ArrayList<String> validateRequiredParams() {
-        ArrayList<String> errors = new ArrayList<>();
-        if (caseId == null) {
-            errors.add(getText(R.string.missing_case_id).toString());
-        }
-        return errors;
-    }
 }

--- a/app/src/main/java/com/dimagi/biometric/activities/VerifyActivity.java
+++ b/app/src/main/java/com/dimagi/biometric/activities/VerifyActivity.java
@@ -1,12 +1,8 @@
 package com.dimagi.biometric.activities;
 
-import com.dimagi.biometric.R;
-
 import org.commcare.commcaresupportlibrary.identity.IdentityResponseBuilder;
 import org.commcare.commcaresupportlibrary.identity.model.MatchResult;
 import org.commcare.commcaresupportlibrary.identity.model.MatchStrength;
-
-import java.util.ArrayList;
 
 import Tech5.OmniMatch.MatcherCommon;
 

--- a/app/src/main/java/com/dimagi/biometric/fragments/BaseMatchFragment.java
+++ b/app/src/main/java/com/dimagi/biometric/fragments/BaseMatchFragment.java
@@ -30,6 +30,8 @@ import com.dimagi.biometric.R;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.dimagi.biometric.activities.BaseActivity.ERROR_MESSAGES_BUNDLE_KEY;
+
 /**
  * A base class to contain common functionality for both the face and finger match fragments.
  */
@@ -82,7 +84,7 @@ public abstract class BaseMatchFragment extends Fragment {
     private void handleStartButtonValidation(Bundle args, @NonNull View view) {
         String errors = null;
         if (args != null) {
-            errors = args.getString("errors");
+            errors = args.getString(ERROR_MESSAGES_BUNDLE_KEY);
         }
         Button startButton = view.findViewById(R.id.start_capture_button);
         if (errors == null) {

--- a/app/src/main/java/com/dimagi/biometric/viewmodels/LicenseViewModel.java
+++ b/app/src/main/java/com/dimagi/biometric/viewmodels/LicenseViewModel.java
@@ -30,6 +30,7 @@ import Tech5.OmniMatch.JNI.OmniMatchException;
 public class LicenseViewModel extends AndroidViewModel {
 
     private static final String TAG = "BIOMETRIC";
+    private static final String PROJECT_ID_FOR_TESTING = "TEST";
 
     private final Application application;
 
@@ -55,11 +56,11 @@ public class LicenseViewModel extends AndroidViewModel {
 
     public LiveData<initStatus> getStatus() { return status; }
 
-    public void initSDK(Context context) {
+    public void initSDK(Context context, String projectId) {
 
         new Thread(() -> {
             statusMessage.postValue(application.getResources().getString(R.string.omnimatch_initializing));
-            boolean isSDKInitialized = loadLicense(context);
+            boolean isSDKInitialized = loadLicense(context, projectId);
             if (isSDKInitialized) {
                 status.postValue(initStatus.SUCCESS);
             } else {
@@ -69,7 +70,7 @@ public class LicenseViewModel extends AndroidViewModel {
         }).start();
     }
 
-    private boolean loadLicense(Context context) {
+    private boolean loadLicense(Context context, String projectId) {
         int resultCode;
         try {
             CoreNative coreNative = new CoreNative();
@@ -84,7 +85,7 @@ public class LicenseViewModel extends AndroidViewModel {
                     return false;
                 }
 
-                String url = "https://pheonix-lic.tech5.tech/license/" + application.getApplicationContext().getPackageName() + "/" + Math.abs(resultCode);
+                String url = "https://pheonix-lic.tech5.tech/license/" + application.getApplicationContext().getPackageName() + getUrlDomainSuffix(projectId) + "/" + Math.abs(resultCode);
                 String token = sendHttpRequest(url);
                 if (token == null) {
                     throw new IOException();
@@ -100,6 +101,14 @@ public class LicenseViewModel extends AndroidViewModel {
         }
 
         return (resultCode == 0);
+    }
+
+    private String getUrlDomainSuffix(String projectId) {
+        if (projectId.equalsIgnoreCase(PROJECT_ID_FOR_TESTING)) {
+            return "";
+        } else {
+            return "." + projectId.toLowerCase();
+        }
     }
 
     private String sendHttpRequest(String urlString) throws IOException {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="missing_case_id">Missing required \"case_id\" input parameter.</string>
     <string name="missing_project_id">Missing required \"project_id\" input parameter.</string>
     <string name="missing_template_str">Missing required \"template\" input parameter.</string>
+    <string name="invalid_project_id">project_id cannot contain blank spaces</string>
 
     <string name="permission_rationale">This app requires the Camera and CommCare Read permissions in order to do biometric capture and matching.</string>
     <string name="permission_settings">You will need to navigate to the app settings to enable the required permissions.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="connection_failed">No network available to initialize OmniMatch license</string>
     <string name="license_validation_failed">Failed to validate OmniMatch license</string>
     <string name="missing_case_id">Missing required \"case_id\" input parameter.</string>
+    <string name="missing_project_id">Missing required \"project_id\" input parameter.</string>
     <string name="missing_template_str">Missing required \"template\" input parameter.</string>
 
     <string name="permission_rationale">This app requires the Camera and CommCare Read permissions in order to do biometric capture and matching.</string>


### PR DESCRIPTION
This PR adds the project Id to the License validation request to workaround the Tech5 licensing model restrictions related to _multi-tenant_ apps. Each Tech5 license is linked to an app package name, and given that CommCare is used by several organizations, we would be forced to have an `apk` of the Biometric app for each project using it. The project Id above mentioned is added as a suffix to the url domain, making it unique across the different projects using CommCare. 

Note, app builders will now have to include a new extra named `project_id` to the app callout question. This extra can be any non-spaced string and it's required, so failing to add it will result in the message illustrated below. 
![Screenshot_20240606-102446_Biometric Capture](https://github.com/dimagi/biometric-android/assets/19228119/08f5a350-d867-4217-9833-771aea45cf0c)
