### PR TITLE
Bump CommCare Support Library to version 12.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    implementation 'org.commcarehq.commcare:support-library:12.4'
+    implementation 'org.commcarehq.commcare:support-library:12.5'
 
     def camerax_version = '1.2.3'
     implementation "androidx.camera:camera-core:$camerax_version"


### PR DESCRIPTION
This is to bump CommCare Support Library to the latest version. 