### PR TITLE
Makes String comparison null safe

### DIFF
--- a/app/src/main/java/com/dimagi/biometric/viewmodels/LicenseViewModel.java
+++ b/app/src/main/java/com/dimagi/biometric/viewmodels/LicenseViewModel.java
@@ -104,7 +104,7 @@ public class LicenseViewModel extends AndroidViewModel {
     }
 
     private String getUrlDomainSuffix(String projectId) {
-        if (PROJECT_ID_FOR_TESTING.equalsIgnoreCase(projectId)) {
+        if (projectId == null || PROJECT_ID_FOR_TESTING.equalsIgnoreCase(projectId)) {
             return "";
         } else {
             return "." + projectId.toLowerCase();


### PR DESCRIPTION
In case `Project Id` is not set, use testing license.